### PR TITLE
Fixing html tbody closing tags

### DIFF
--- a/armTemplate.json
+++ b/armTemplate.json
@@ -82,7 +82,7 @@
                         "Close_HTML_tags": {
                             "inputs": {
                                 "name": "html",
-                                "value": "<tbody></table>"
+                                "value": "</tbody></table>"
                             },
                             "runAfter": {
                                 "Until": [


### PR DESCRIPTION
In "Close HTML tags", '\<tbody\>' was added instead of a tbody closure '\</tbody\>'